### PR TITLE
Table view

### DIFF
--- a/components/pages/Navigation.tsx
+++ b/components/pages/Navigation.tsx
@@ -9,6 +9,7 @@ const ITEMS = [
   { label: "Mostly Everything", href: "/artworks" },
   { label: "Only Websites", href: "/websites" },
   { label: "Exhibitions", href: "/exhibitions" },
+  { label: "Table", href: "/table" },
   { label: "Information", href: "/information" },
 ];
 

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1403,7 +1403,7 @@ export type ArtworksIndexQuery = { __typename?: 'Query', artworks: Array<{ __typ
 export type ArtworksTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ArtworksTableQuery = { __typename?: 'Query', artworks: Array<{ __typename?: 'Artwork', id: string, slug: string, title: string, material?: string | null, year: number }> };
+export type ArtworksTableQuery = { __typename?: 'Query', artworks: Array<{ __typename?: 'Artwork', id: string, slug: string, title: string, material?: string | null, year: number, duration?: string | null, collector_byline?: string | null, dimensions?: { __typename?: 'Dimensions', inches: { __typename?: 'Dimension', to_s?: string | null }, centimeters: { __typename?: 'Dimension', to_s?: string | null } } | null }> };
 
 export type TagShowQueryVariables = Exact<{
   id: Scalars['ID'];
@@ -1861,6 +1861,16 @@ export const ArtworksTableQueryDocument = gql`
     title
     material
     year
+    duration
+    dimensions {
+      inches {
+        to_s
+      }
+      centimeters {
+        to_s
+      }
+    }
+    collector_byline
   }
 }
     `;

--- a/generated/graphql.tsx
+++ b/generated/graphql.tsx
@@ -1403,7 +1403,7 @@ export type ArtworksIndexQuery = { __typename?: 'Query', artworks: Array<{ __typ
 export type ArtworksTableQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ArtworksTableQuery = { __typename?: 'Query', artworks: Array<{ __typename?: 'Artwork', id: string, slug: string, title: string, material?: string | null, year: number, duration?: string | null, collector_byline?: string | null, dimensions?: { __typename?: 'Dimensions', inches: { __typename?: 'Dimension', to_s?: string | null }, centimeters: { __typename?: 'Dimension', to_s?: string | null } } | null }> };
+export type ArtworksTableQuery = { __typename?: 'Query', artworks: Array<{ __typename?: 'Artwork', id: string, slug: string, title: string, material?: string | null, year: number, duration?: string | null, dimensions?: { __typename?: 'Dimensions', inches: { __typename?: 'Dimension', to_s?: string | null }, centimeters: { __typename?: 'Dimension', to_s?: string | null } } | null }> };
 
 export type TagShowQueryVariables = Exact<{
   id: Scalars['ID'];
@@ -1870,7 +1870,6 @@ export const ArtworksTableQueryDocument = gql`
         to_s
       }
     }
-    collector_byline
   }
 }
     `;

--- a/pages/table.tsx
+++ b/pages/table.tsx
@@ -1,11 +1,18 @@
 import { gql } from "urql";
 import Link from "next/link";
-import { Cell, Stack } from "@auspices/eos/client";
+import { Box, Cell, ClearableInput, Stack } from "@auspices/eos/client";
+import { useState } from "react";
+import styled from "styled-components";
+import { themeGet } from "@styled-system/theme-get";
 import { Table } from "../components/core/Table";
-import { useArtworksTableQuery } from "../generated/graphql";
-import { NavigationLayout } from "../components/layouts/NavigationLayout";
+import {
+  ArtworksTableQuery,
+  useArtworksTableQuery,
+} from "../generated/graphql";
+import { Back } from "../components/core/Back";
 import { Loading } from "../components/core/Loading";
 import { Meta } from "../components/core/Meta";
+import { Page } from "../components/core/Page";
 import { buildGetStaticProps, withUrql } from "../lib/urql";
 
 const ARTWORKS_TABLE_QUERY = gql`
@@ -16,12 +23,160 @@ const ARTWORKS_TABLE_QUERY = gql`
       title
       material
       year
+      duration
+      dimensions {
+        inches {
+          to_s
+        }
+        centimeters {
+          to_s
+        }
+      }
     }
+  }
+`;
+
+type Artwork = ArtworksTableQuery["artworks"][number];
+type SortKey = "title" | "material" | "year" | "dimensions" | "duration";
+type SortDirection = "ascending" | "descending";
+
+const columns: Array<{
+  key: SortKey;
+  label: string;
+  align?: "left" | "center";
+}> = [
+  { key: "title", label: "title" },
+  { key: "material", label: "material" },
+  { key: "year", label: "year", align: "center" },
+  { key: "dimensions", label: "dimensions" },
+  { key: "duration", label: "duration" },
+];
+
+const dimensionsToString = (artwork: Artwork) => {
+  if (!artwork.dimensions) return null;
+
+  const inches = artwork.dimensions.inches.to_s;
+  const centimeters = artwork.dimensions.centimeters.to_s;
+
+  return [inches, centimeters].filter(Boolean).join(" / ") || null;
+};
+
+const sortValue = (artwork: Artwork, key: SortKey): string | number | null => {
+  switch (key) {
+    case "dimensions":
+      return dimensionsToString(artwork);
+    default:
+      return artwork[key] ?? null;
+  }
+};
+
+const compareArtworks = (
+  left: Artwork,
+  right: Artwork,
+  key: SortKey,
+  direction: SortDirection,
+) => {
+  const leftValue = sortValue(left, key);
+  const rightValue = sortValue(right, key);
+
+  if (
+    (leftValue == null || leftValue === "") &&
+    (rightValue == null || rightValue === "")
+  ) {
+    return 0;
+  }
+  if (leftValue == null || leftValue === "") return 1;
+  if (rightValue == null || rightValue === "") return -1;
+
+  const comparison =
+    typeof leftValue === "number" && typeof rightValue === "number"
+      ? leftValue - rightValue
+      : String(leftValue).localeCompare(String(rightValue), undefined, {
+          numeric: true,
+          sensitivity: "base",
+        });
+
+  return direction === "ascending" ? comparison : -comparison;
+};
+
+const artworkMatchesFilter = (artwork: Artwork, filter: string) => {
+  const query = filter.trim().toLocaleLowerCase();
+
+  if (!query) return true;
+
+  return columns.some((column) =>
+    String(sortValue(artwork, column.key) ?? "")
+      .toLocaleLowerCase()
+      .includes(query),
+  );
+};
+
+const SheetPage = styled(Page)`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
+  margin-bottom: 0;
+  padding: 0;
+  overflow: hidden;
+`;
+
+const SheetToolbar = styled(Stack)`
+  flex: none;
+`;
+
+const TableScroller = styled(Box)`
+  flex: 1;
+  min-height: 0;
+  margin-top: -1px;
+  max-width: 100%;
+  overflow: auto;
+`;
+
+const CompactTable = styled(Table)`
+  min-width: 72rem;
+
+  thead th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: ${themeGet("colors.background")};
+    outline: 1px solid ${themeGet("primary")};
+    outline-offset: -1px;
+  }
+
+  td,
+  th {
+    white-space: nowrap;
+  }
+`;
+
+const SortButton = styled.button`
+  display: block;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  text-align: inherit;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 1px solid currentColor;
+    outline-offset: -1px;
   }
 `;
 
 const ArtworksTablePage = () => {
   const [{ fetching, error, data }] = useArtworksTableQuery();
+  const [sort, setSort] = useState<{
+    key: SortKey;
+    direction: SortDirection;
+  } | null>(null);
+  const [filter, setFilter] = useState("");
 
   if (error) {
     throw error;
@@ -32,69 +187,139 @@ const ArtworksTablePage = () => {
   }
 
   const { artworks } = data;
+  const filteredArtworks = artworks.filter((artwork) =>
+    artworkMatchesFilter(artwork, filter),
+  );
+  const sortedArtworks = sort
+    ? [...filteredArtworks].sort((left, right) =>
+        compareArtworks(left, right, sort.key, sort.direction),
+      )
+    : filteredArtworks;
+
+  const handleSort = (key: SortKey) => {
+    setSort((current) => ({
+      key,
+      direction:
+        current?.key === key && current.direction === "ascending"
+          ? "descending"
+          : "ascending",
+    }));
+  };
 
   return (
-    <>
+    <SheetPage>
       <Meta title="Damon Zucconi" />
 
-      <>
-        <Stack spacing={6}>
-          <Table position="relative" borderWidth={0}>
-            <thead>
-              <tr>
-                <th>
-                  <Cell borderWidth={0}>title</Cell>
-                </th>
-                <th>
-                  <Cell borderWidth={0}>material</Cell>
-                </th>
-                <th>
-                  <Cell borderWidth={0} textAlign="center">
-                    year
-                  </Cell>
-                </th>
-              </tr>
-            </thead>
+      <SheetToolbar direction="horizontal">
+        <Back variant="default" />
 
-            <tbody>
-              {artworks.map((artwork) => {
+        <ClearableInput
+          variant="default"
+          flex={1}
+          minWidth={0}
+          onChange={setFilter}
+          placeholder="Filter artworks"
+          aria-label="Filter artworks"
+        />
+      </SheetToolbar>
+
+      <TableScroller tabIndex={0} aria-label="Artwork table">
+        <CompactTable position="relative">
+          <thead>
+            <tr>
+              {columns.map((column) => {
+                const isActive = sort?.key === column.key;
+                const nextDirection =
+                  isActive && sort.direction === "ascending"
+                    ? "descending"
+                    : "ascending";
+
                 return (
-                  <tr key={artwork.id}>
-                    <td>
-                      <Link
-                        key={artwork.id}
-                        href={`/artworks/${artwork.slug}`}
-                        aria-label={`${artwork.title}; ${artwork.material} (${artwork.year})`}
-                        passHref
-                        legacyBehavior
+                  <th
+                    key={column.key}
+                    aria-sort={isActive ? sort.direction : "none"}
+                  >
+                    <SortButton
+                      type="button"
+                      onClick={() => handleSort(column.key)}
+                      aria-label={`Sort by ${column.label} ${nextDirection}`}
+                    >
+                      <Cell
+                        as="span"
+                        variant="small"
+                        borderWidth={0}
+                        display="block"
+                        textAlign={column.align}
                       >
-                        <Cell as="a" borderWidth={0} display="block">
-                          {artwork.title}
-                        </Cell>
-                      </Link>
-                    </td>
-
-                    <td>
-                      <Cell borderWidth={0}>{artwork.material}</Cell>
-                    </td>
-
-                    <td>
-                      <Cell borderWidth={0} textAlign="center">
-                        {artwork.year}
+                        {column.label}
+                        {isActive && (
+                          <span aria-hidden="true">
+                            {sort.direction === "ascending" ? " ↑" : " ↓"}
+                          </span>
+                        )}
                       </Cell>
-                    </td>
-                  </tr>
+                    </SortButton>
+                  </th>
                 );
               })}
-            </tbody>
-          </Table>
-        </Stack>
-      </>
-    </>
+            </tr>
+          </thead>
+
+          <tbody>
+            {sortedArtworks.map((artwork) => {
+              return (
+                <tr key={artwork.id}>
+                  <td>
+                    <Link
+                      key={artwork.id}
+                      href={`/artworks/${artwork.slug}`}
+                      aria-label={`${artwork.title}; ${artwork.material} (${artwork.year})`}
+                      passHref
+                      legacyBehavior
+                    >
+                      <Cell
+                        as="a"
+                        variant="small"
+                        borderWidth={0}
+                        display="block"
+                      >
+                        {artwork.title}
+                      </Cell>
+                    </Link>
+                  </td>
+
+                  <td>
+                    <Cell variant="small" borderWidth={0}>
+                      {artwork.material ?? "—"}
+                    </Cell>
+                  </td>
+
+                  <td>
+                    <Cell variant="small" borderWidth={0} textAlign="center">
+                      {artwork.year}
+                    </Cell>
+                  </td>
+
+                  <td>
+                    <Cell variant="small" borderWidth={0}>
+                      {dimensionsToString(artwork) ?? "—"}
+                    </Cell>
+                  </td>
+
+                  <td>
+                    <Cell variant="small" borderWidth={0}>
+                      {artwork.duration ?? "—"}
+                    </Cell>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </CompactTable>
+      </TableScroller>
+    </SheetPage>
   );
 };
-
-ArtworksTablePage.getLayout = NavigationLayout;
 
 export default withUrql(ArtworksTablePage);
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Frontend-only table UX; no auth, data mutation, or API contract changes beyond fetching extra display fields.
> 
> **Overview**
> Turns `/table` into a full-viewport spreadsheet of published/selected artworks, with a filter field, click-to-sort columns, sticky headers, and a back control instead of the site nav layout.
> 
> Adds **dimensions** (inches/cm) and **duration** columns, fetched via `ArtworksTableQuery`. Empty values show as em dashes. Sorting is client-side (numeric for year, locale-aware otherwise; blanks last). Filter matches any column.
> 
> A **Table** item is added to site navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810af2fdbabb33ca54bad6590350e7e6508524a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->